### PR TITLE
Ensure the player has not been combat tagged

### DIFF
--- a/duels-plugin/src/main/java/me/realized/duels/command/commands/duel/subcommands/AcceptCommand.java
+++ b/duels-plugin/src/main/java/me/realized/duels/command/commands/duel/subcommands/AcceptCommand.java
@@ -88,6 +88,11 @@ public class AcceptCommand extends BaseCommand {
             return;
         }
 
+        if ((combatTagPlus != null && combatTagPlus.isTagged(target)) || (pvpManager != null && pvpManager.isTagged(target))) {
+            lang.sendMessage(sender, "ERROR.duel.is-tagged");
+            return;
+        }
+
         final Settings settings = request.getSettings();
         final String kit = settings.getKit() != null ? settings.getKit().getName() : "Not Selected";
         final String arena = settings.getArena() != null ? settings.getArena().getName() : "Random";


### PR DESCRIPTION
While running the duels plugin, I found that if a player sends a request before getting CombatTagged then gets CombatTagged, the duel can still be accepted. 