### PR TITLE
Revert "Ensure the player has not been combat tagged"

### DIFF
--- a/duels-plugin/src/main/java/me/realized/duels/command/commands/duel/subcommands/AcceptCommand.java
+++ b/duels-plugin/src/main/java/me/realized/duels/command/commands/duel/subcommands/AcceptCommand.java
@@ -88,11 +88,6 @@ public class AcceptCommand extends BaseCommand {
             return;
         }
 
-        if ((combatTagPlus != null && combatTagPlus.isTagged(target)) || (pvpManager != null && pvpManager.isTagged(target))) {
-            lang.sendMessage(sender, "ERROR.duel.is-tagged");
-            return;
-        }
-
         final Settings settings = request.getSettings();
         final String kit = settings.getKit() != null ? settings.getKit().getName() : "Not Selected";
         final String arena = settings.getArena() != null ? settings.getArena().getName() : "Random";


### PR DESCRIPTION
Reverts Realizedd/Duels#8

Looks like the check in the commit already exists. It will need to be added to [DuelManager#startMatch](https://github.com/Realizedd/Duels/blob/master/duels-plugin/src/main/java/me/realized/duels/duel/DuelManager.java#L300) instead.