### PR TITLE
Typo Fix

### DIFF
--- a/duels-plugin/build.gradle
+++ b/duels-plugin/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     compile project(':duels-api')
     compile 'com.google.code.gson:gson:2.8.2'
-    compile 'org.inventivetalent.spiget-update:bukkit:1.4.+'
+    compile 'org.inventivetalent.spiget-update:bukkit:1.4.2-SNAPSHOT'
 }
 
 shadowJar {

--- a/duels-plugin/build.gradle
+++ b/duels-plugin/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     compile project(':duels-api')
     compile 'com.google.code.gson:gson:2.8.2'
-    compile 'org.inventivetalent.spiget-update:bukkit:1.4.0'
+    compile 'org.inventivetalent.spiget-update:bukkit:1.4.+'
 }
 
 shadowJar {

--- a/duels-plugin/src/main/java/me/realized/duels/hook/hooks/MVdWPlaceholderHook.java
+++ b/duels-plugin/src/main/java/me/realized/duels/hook/hooks/MVdWPlaceholderHook.java
@@ -43,7 +43,7 @@ public class MVdWPlaceholderHook extends PluginHook<DuelsPlugin> {
                 case "duels_wins":
                     return String.valueOf(user.getWins());
                 case "duels_losses":
-                    return String.valueOf(user.getWins());
+                    return String.valueOf(user.getLosses());
                 case "duels_can_request":
                     return String.valueOf(user.canRequest());
             }

--- a/duels-plugin/src/main/java/me/realized/duels/hook/hooks/PlaceholderHook.java
+++ b/duels-plugin/src/main/java/me/realized/duels/hook/hooks/PlaceholderHook.java
@@ -55,7 +55,7 @@ public class PlaceholderHook extends PluginHook<DuelsPlugin> {
                 case "wins":
                     return String.valueOf(user.getWins());
                 case "losses":
-                    return String.valueOf(user.getWins());
+                    return String.valueOf(user.getLosses());
                 case "can_request":
                     return String.valueOf(user.canRequest());
             }


### PR DESCRIPTION
1. spiget-update 1.4.0's pom file seems to be corrupted and doesn't compile, so it was changed to the latest version

2. duels_losses placeholder was using getWins() instead of getLosses()