### PR TITLE
Fixes #92 - Set firework power to 0

### DIFF
--- a/duels-plugin/src/main/java/me/realized/duels/duel/DuelManager.java
+++ b/duels-plugin/src/main/java/me/realized/duels/duel/DuelManager.java
@@ -562,6 +562,7 @@ public class DuelManager implements Loadable {
                 if (config.isSpawnFirework()) {
                     final Firework firework = (Firework) winner.getWorld().spawnEntity(winner.getEyeLocation(), EntityType.FIREWORK);
                     final FireworkMeta meta = firework.getFireworkMeta();
+                    meta.setPower(0);
                     meta.addEffect(FireworkEffect.builder().withColor(Color.RED).with(FireworkEffect.Type.BALL_LARGE).withTrail().build());
                     firework.setFireworkMeta(meta);
                 }


### PR DESCRIPTION
Closes #92 

Pre-paper build 366, when power was `null`, it threw an NPE. Paper uses 0 as a default when power is `null`, so consistent behaviour is kept.